### PR TITLE
Support unicode keys

### DIFF
--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -31,7 +31,7 @@ impl From<String> for Key {
 }
 
 fn convert_str_to_termion_event(s: &str) -> TEvent {
-    if s.len() == 1 {
+    if s.chars().count() == 1 {
         return TEvent::Key(TKey::Char(s.chars().last().unwrap()));
     }
 


### PR DESCRIPTION
In the top corner of a mac keyboard (at least in the uk) there is a key with this char: '§'.

If I try to bind it for exiting, it doesn't work, because the model uses chars to represent keys, but it checks the length of the configuration in bytes, not chars. This fixes it.

P.S. I've been looking for something like this for a long, long time. I use a clone of vim for my editor of choice ([kakoune](https://github.com/mawww/kakoune)), which doesn't have anything like _nerdtree_, so many, many thanks for this!